### PR TITLE
Fix behavior of 'variables' module

### DIFF
--- a/vim/variable.ts
+++ b/vim/variable.ts
@@ -8,17 +8,16 @@ import { Denops } from "../deps.ts";
  * w - Window local variables
  * t - Tab page local variables
  * v - Vim's variables
- * env - Environment variables
  *
  */
-export type VariableGroups = "g" | "b" | "w" | "t" | "v" | "env";
+export type VariableGroups = "g" | "b" | "w" | "t" | "v";
 
 export async function getVar<T = unknown>(
   denops: Denops,
   group: VariableGroups,
   prop: string,
 ): Promise<T> {
-  const name = group === "env" ? `\$${prop}` : `${group}:${prop}`;
+  const name = `${group}:${prop}`;
   // deno-lint-ignore no-explicit-any
   return (await denops.eval(name)) as any;
 }
@@ -29,7 +28,7 @@ export async function setVar<T = unknown>(
   prop: string,
   value: T,
 ): Promise<void> {
-  const name = group === "env" ? `\$${prop}` : `${group}:${prop}`;
+  const name = `${group}:${prop}`;
   await denops.cmd(`let ${name} = value`, {
     value,
   });
@@ -40,7 +39,7 @@ export async function removeVar(
   group: VariableGroups,
   prop: string,
 ): Promise<void> {
-  const name = group === "env" ? `\$${prop}` : `${group}:${prop}`;
+  const name = `${group}:${prop}`;
   await denops.cmd(`unlet ${name}`);
 }
 

--- a/vim/variable.ts
+++ b/vim/variable.ts
@@ -16,10 +16,14 @@ export async function getVar<T = unknown>(
   denops: Denops,
   group: VariableGroups,
   prop: string,
-): Promise<T> {
-  const name = `${group}:${prop}`;
+  defaultValue?: T,
+): Promise<T | null> {
+  const result = await denops.eval(`get(${group}:, name, value)`, {
+    name: prop,
+    value: defaultValue ?? null,
+  });
   // deno-lint-ignore no-explicit-any
-  return (await denops.eval(name)) as any;
+  return result as any;
 }
 
 export async function setVar<T = unknown>(
@@ -52,8 +56,8 @@ export class VariableHelper {
     this.#group = group;
   }
 
-  async get<T = unknown>(prop: string): Promise<T> {
-    return await getVar(this.#denops, this.#group, prop);
+  async get<T = unknown>(prop: string, defaultValue?: T): Promise<T | null> {
+    return await getVar(this.#denops, this.#group, prop, defaultValue);
   }
 
   async set<T = unknown>(prop: string, value: T): Promise<void> {

--- a/vim/vim.ts
+++ b/vim/vim.ts
@@ -11,7 +11,6 @@ export class Vim {
   readonly w: VariableHelper;
   readonly t: VariableHelper;
   readonly v: VariableHelper;
-  readonly env: VariableHelper;
 
   constructor(denops: Denops) {
     this.#denops = denops;
@@ -20,7 +19,6 @@ export class Vim {
     this.w = new VariableHelper(denops, "w");
     this.t = new VariableHelper(denops, "t");
     this.v = new VariableHelper(denops, "v");
-    this.env = new VariableHelper(denops, "env");
   }
 
   static get(): Vim {


### PR DESCRIPTION
1. Remove 'env' type which is quite different from others
2. Add `defaultValue` argument to fix behavior difference between Vim/Neovim (#5)