### PR TITLE
Add 'main()' and deprecate 'start()'

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,5 +1,5 @@
 export type {
   Context,
   Dispatcher,
-} from "https://deno.land/x/denops_core@v0.10.0/mod.ts";
-export { Denops } from "https://deno.land/x/denops_core@v0.10.0/mod.ts";
+} from "https://deno.land/x/denops_core@v0.11.0/mod.ts";
+export { Denops } from "https://deno.land/x/denops_core@v0.11.0/mod.ts";

--- a/deps_test.ts
+++ b/deps_test.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.92.0/testing/asserts.ts";
+export * from "https://deno.land/std@0.93.0/testing/asserts.ts";

--- a/main.ts
+++ b/main.ts
@@ -1,0 +1,21 @@
+import { Denops } from "./deps.ts";
+import { Vim } from "./vim/mod.ts";
+
+export interface RunnerContext {
+  denops: Denops;
+  vim: Vim;
+}
+
+/**
+ * Define a plugin main function which starts denops mainloop for the plugin
+ */
+export function main(runner: (context: RunnerContext) => Promise<void>) {
+  Denops.start(async (denops) => {
+    const vim = Vim.get();
+    const ctx: RunnerContext = {
+      denops,
+      vim,
+    };
+    await runner(ctx);
+  });
+}

--- a/mod.ts
+++ b/mod.ts
@@ -1,1 +1,5 @@
-export { start, Vim } from "./vim/mod.ts";
+export { Vim } from "./vim/mod.ts";
+export { main } from "./main.ts";
+
+// Deprecated APIs
+export { start } from "./vim/mod.ts";

--- a/vim/vim.ts
+++ b/vim/vim.ts
@@ -4,7 +4,7 @@ import { autocmd, AutocmdHelper } from "./autocmd.ts";
 import { VariableHelper } from "./variable.ts";
 
 export class Vim {
-  static instance?: Vim;
+  private static instance?: Vim;
 
   #denops: Denops;
 
@@ -65,6 +65,26 @@ export class Vim {
   }
 }
 
+/**
+ * Define a plugin main function which starts denops mainloop for the plugin
+ * @deprecated Use `main` function instead.
+ */
 export function start(main: (vim: Vim) => Promise<void>) {
-  Denops.start(() => main(Vim.get()));
+  Denops.start(async () => {
+    const vim = Vim.get();
+    console.warn(
+      `${vim.name}: The 'start()' is deprecated since denops_std@v0.8.`,
+    );
+    console.warn(
+      `${vim.name}: Use 'main()' instead to launch a plugin like:`,
+    );
+    console.warn(`${vim.name}:`);
+    console.warn(`${vim.name}:   main(async ({ vim }) => {`);
+    console.warn(`${vim.name}:     vim.register({`);
+    console.warn(`${vim.name}:       // ...`);
+    console.warn(`${vim.name}:     });`);
+    console.warn(`${vim.name}:   });`);
+    console.warn(`${vim.name}:`);
+    await main(vim);
+  });
 }


### PR DESCRIPTION
Now `start()` become deprecated and new `main()` is added. Plugin developers should use `main()` like:

```typescript
import { main } from "https://deno.land/x/denops_std/mod.ts";

main(async ({ vim }) => {
  // ...
});
```

Because the first argument become a context object, any named attributes are easily added in future like:

```typescript
import { main } from "https://deno.land/x/denops_std/mod.ts";

main(async ({ vim, denops }) => {
  // Call other plugin's API through `denops` instance
  await denops.dispatch(...);
  // ...
});
```

Wait for https://github.com/vim-denops/denops.vim/pull/33 and new release.