### PR TITLE
Add tests for `variable` module as test writing example

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: deno
 
 env:
   DENO_VERSION: 1.x
+  DENOPS_PATH: "./denops.vim"
 
 on:
   schedule:
@@ -42,9 +43,38 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+        with:
+          repository: "vim-denops/denops.vim"
+          path: "denops.vim"
       - uses: denoland/setup-deno@main
         with:
           deno-version: ${{ env.DENO_VERSION }}
+      - uses: rhysd/action-setup-vim@v1
+        id: vim
+        with:
+          version: "v8.1.2424"
+      - uses: rhysd/action-setup-vim@v1
+        id: nvim
+        with:
+          neovim: true
+          version: "v0.4.4"
+      - name: Check Vim
+        run: |
+          echo ${DENOPS_TEST_VIM}
+          ${DENOPS_TEST_VIM} --version
+        env:
+          DENOPS_TEST_VIM: ${{ steps.vim.outputs.executable }}
+      - name: Check Neovim
+        run: |
+          echo ${DENOPS_TEST_NVIM}
+          ${DENOPS_TEST_NVIM} --version
+        env:
+          DENOPS_TEST_NVIM: ${{ steps.nvim.outputs.executable }}
       - name: Test
         run: |
-          deno test
+          deno test --unstable -A
+        env:
+          DENOPS_TEST_VIM: ${{ steps.vim.outputs.executable }}
+          DENOPS_TEST_NVIM: ${{ steps.nvim.outputs.executable }}
+        timeout-minutes: 5

--- a/deps.ts
+++ b/deps.ts
@@ -5,11 +5,11 @@ export * as fs from "https://deno.land/std@0.95.0/fs/mod.ts";
 export type {
   Context,
   Dispatcher,
-} from "https://deno.land/x/denops_core@v0.13.0/mod.ts";
+} from "https://deno.land/x/denops_core@v0.16.0/mod.ts";
 export {
   Denops,
   ensureArray,
   ensureNumber,
   ensureRecord,
   ensureString,
-} from "https://deno.land/x/denops_core@v0.13.0/mod.ts";
+} from "https://deno.land/x/denops_core@v0.16.0/mod.ts";

--- a/test.ts
+++ b/test.ts
@@ -1,5 +1,0 @@
-import { assertEquals } from "./deps_test.ts";
-
-Deno.test("1 + 1 = 2", () => {
-  assertEquals(1 + 1, 2);
-});

--- a/vim/variable_test.ts
+++ b/vim/variable_test.ts
@@ -1,0 +1,35 @@
+import { Denops } from "../deps.ts";
+import { assertEquals } from "../deps_test.ts";
+import * as variable from "./variable.ts";
+
+Denops.test("getVar() return the value of the variable", async (denops) => {
+  await denops.cmd("let g:denops_std_vim_variable_test = 'hello'");
+  const result = await variable.getVar(
+    denops,
+    "g",
+    "denops_std_vim_variable_test",
+  );
+  assertEquals(result, "hello");
+});
+
+Denops.test("setVar() replace the value of the variable", async (denops) => {
+  await denops.cmd("let g:denops_std_vim_variable_test = 'hello'");
+  await variable.setVar(denops, "g", "denops_std_vim_variable_test", "world");
+  const result = await variable.getVar(
+    denops,
+    "g",
+    "denops_std_vim_variable_test",
+  );
+  assertEquals(result, "world");
+});
+
+Denops.test("removeVar() remove the variable", async (denops) => {
+  await denops.cmd("let g:denops_std_vim_variable_test = 'hello'");
+  await variable.removeVar(denops, "g", "denops_std_vim_variable_test");
+  const result = await variable.getVar(
+    denops,
+    "g",
+    "denops_std_vim_variable_test",
+  );
+  assertEquals(result, null);
+});


### PR DESCRIPTION
Denops v0.16.0 supports testing with denops thus I've added example test.