### PR TITLE
:+1: Add a priority property to Decoration

### DIFF
--- a/buffer/decoration_test.ts
+++ b/buffer/decoration_test.ts
@@ -54,7 +54,7 @@ test({
       length: 5,
       lnum: 1,
       start: 1,
-      type: "denops_std:buffer:decoration:decorate:denops-test:Title",
+      type: "denops_std:buffer:decoration:decorate:denops-test:0:Title",
       type_bufnr: 0,
     }, {
       col: 2,
@@ -62,7 +62,7 @@ test({
       length: 3,
       lnum: 2,
       start: 1,
-      type: "denops_std:buffer:decoration:decorate:denops-test:Search",
+      type: "denops_std:buffer:decoration:decorate:denops-test:0:Search",
       type_bufnr: 0,
     }]);
 
@@ -125,6 +125,54 @@ test({
 
 test({
   mode: "all",
+  name:
+    "decorate defines each highlight when multiple decorations have different priorities",
+  fn: async (denops) => {
+    const bufnr = await fn.bufnr(denops);
+    await buffer.replace(denops, bufnr, [
+      "Hello",
+      "World",
+    ]);
+
+    await decorate(denops, bufnr, [
+      {
+        line: 1,
+        column: 1,
+        length: 5,
+        highlight: "Title",
+        priority: 10,
+      },
+      {
+        line: 2,
+        column: 1,
+        length: 5,
+        highlight: "Title",
+        priority: 20,
+      },
+    ]);
+
+    const decorations = await listDecorations(denops, bufnr);
+    assertEquals(decorations, [
+      {
+        line: 1,
+        column: 1,
+        length: 5,
+        highlight: "Title",
+        priority: 10,
+      },
+      {
+        line: 2,
+        column: 1,
+        length: 5,
+        highlight: "Title",
+        priority: 20,
+      },
+    ]);
+  },
+});
+
+test({
+  mode: "all",
   name: "listDecorations list decorations defined in the buffer",
   fn: async (denops) => {
     const bufnr = await fn.bufnr(denops);
@@ -146,6 +194,7 @@ test({
         column: 2,
         length: 3,
         highlight: "Search",
+        priority: 10,
       },
     ]);
     assertEquals(await listDecorations(denops, bufnr), [
@@ -154,12 +203,14 @@ test({
         column: 1,
         length: 5,
         highlight: "Title",
+        priority: 0,
       },
       {
         line: 2,
         column: 2,
         length: 3,
         highlight: "Search",
+        priority: 10,
       },
     ]);
   },
@@ -188,6 +239,7 @@ test({
         column: 2,
         length: 3,
         highlight: "Search",
+        priority: 10,
       },
     ]);
     await undecorate(denops, bufnr);
@@ -218,6 +270,7 @@ test({
         column: 2,
         length: 3,
         highlight: "Search",
+        priority: 10,
       },
     ]);
     await undecorate(denops, bufnr, 0, 1);
@@ -227,6 +280,7 @@ test({
         column: 2,
         length: 3,
         highlight: "Search",
+        priority: 10,
       },
     ]);
   },


### PR DESCRIPTION
This Pull Request adds a `priority` property to the `Decoration` interface, allowing users to control the display order of multiple decorations.

The default priority is set to zero to align with the `priority` property of `prop_type_add`.

```vimhelp
prop_type_add({name}, {props})		*prop_type_add()* *E969* *E970*
		Add a text property type {name}.  If a property type with this
		name already exists an error is given.  Nothing is returned.
		{props} is a dictionary with these optional fields:
		   bufnr	define the property only for this buffer; this
				avoids name collisions and automatically
				clears the property types when the buffer is
				deleted.
		   highlight	name of highlight group to use
		   priority	when a character has multiple text
				properties the one with the highest priority
				will be used; negative values can be used, the
				default priority is zero
```

https://github.com/vim/vim/blob/fdeb721251481c26c230a0cd793cb89c2534c206/runtime/doc/textprop.txt#L426-L438

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added optional priority on decorations to control visual stacking order; higher priority renders above lower.
  - Priority is propagated to Vim/Neovim so rendering and listing reflect priority consistently.
  - Decoration listings now include priority; unspecified values default to 0.
  - Backwards compatible: existing usages continue to work without specifying priority.

- Tests
  - Added and updated tests covering multiple priorities, defaulting behavior, and listing assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->