### PR TITLE
:+1: Use Call type from @denops/core v8.0.1

### DIFF
--- a/batch/batch.ts
+++ b/batch/batch.ts
@@ -1,10 +1,10 @@
-import type { Context, Denops, Dispatcher, Meta } from "@denops/core";
+import type { Call, Context, Denops, Dispatcher, Meta } from "@denops/core";
 
 type Redraw = undefined | boolean;
 
 class BatchHelper implements Denops {
   #denops: Denops;
-  #calls: [string, ...unknown[]][];
+  #calls: Call[];
   #redraw: Redraw;
   #closed: boolean;
 
@@ -14,7 +14,7 @@ class BatchHelper implements Denops {
     this.#closed = false;
   }
 
-  static getCalls(helper: BatchHelper): [string, ...unknown[]][] {
+  static getCalls(helper: BatchHelper): Call[] {
     return helper.#calls;
   }
 
@@ -64,7 +64,7 @@ class BatchHelper implements Denops {
     return Promise.resolve();
   }
 
-  batch(...calls: [string, ...unknown[]][]): Promise<unknown[]> {
+  batch(...calls: Call[]): Promise<unknown[]> {
     if (this.#closed) {
       return this.#denops.batch(...calls);
     }

--- a/batch/collect.ts
+++ b/batch/collect.ts
@@ -1,4 +1,4 @@
-import type { Context, Denops, Dispatcher, Meta } from "@denops/core";
+import type { Call, Context, Denops, Dispatcher, Meta } from "@denops/core";
 
 type VimVoid<T> = T extends void ? 0 : T;
 
@@ -8,7 +8,7 @@ type Collect<T extends readonly unknown[] | []> = {
 
 class CollectHelper implements Denops {
   #denops: Denops;
-  #calls: [string, ...unknown[]][];
+  #calls: Call[];
   #closed: boolean;
 
   constructor(denops: Denops) {
@@ -17,7 +17,7 @@ class CollectHelper implements Denops {
     this.#closed = false;
   }
 
-  static getCalls(helper: CollectHelper): [string, ...unknown[]][] {
+  static getCalls(helper: CollectHelper): Call[] {
     return helper.#calls;
   }
 
@@ -63,7 +63,7 @@ class CollectHelper implements Denops {
     return Promise.resolve();
   }
 
-  batch(..._calls: [string, ...unknown[]][]): Promise<unknown[]> {
+  batch(..._calls: Call[]): Promise<unknown[]> {
     throw new Error("The 'batch' method is not available on CollectHelper.");
   }
 

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -37,7 +37,7 @@
   "imports": {
     "@core/asyncutil": "jsr:@core/asyncutil@^1.2.0",
     "@core/unknownutil": "jsr:@core/unknownutil@^4.3.0",
-    "@denops/core": "jsr:@denops/core@^8.0.0",
+    "@denops/core": "jsr:@denops/core@^8.0.1",
     "@denops/test": "jsr:@denops/test@^4.0.0",
     "@lambdalisue/errorutil": "jsr:@lambdalisue/errorutil@^1.1.1",
     "@lambdalisue/itertools": "jsr:@lambdalisue/itertools@^1.1.2",

--- a/eval/use_eval.ts
+++ b/eval/use_eval.ts
@@ -4,7 +4,7 @@
  * @module
  */
 
-import type { Context, Denops, Dispatcher, Meta } from "@denops/core";
+import type { Call, Context, Denops, Dispatcher, Meta } from "@denops/core";
 import { isString } from "@core/unknownutil/is/string";
 import { isUndefined } from "@core/unknownutil/is/undefined";
 import { ulid } from "@std/ulid";
@@ -105,11 +105,11 @@ class UseEvalHelper implements Denops {
     );
   }
 
-  async batch(...calls: [string, ...unknown[]][]): Promise<unknown[]> {
+  async batch(...calls: Call[]): Promise<unknown[]> {
     const suffix = await ensurePrerequisites(this.#denops);
     const callHelper = `DenopsStd_Eval_UseEval_Call_${suffix}`;
     return await this.#denops.batch(
-      ...calls.map(([fn, ...args]): [string, ...unknown[]] => [
+      ...calls.map(([fn, ...args]): Call => [
         callHelper,
         fn,
         stringify(trimEndOfArgs(args)),


### PR DESCRIPTION
Apply the new `Call` type introduced in @denops/core v8.0.1 (https://github.com/vim-denops/deno-denops-core/pull/16).
This replaces the duplicated tuple type `[string, ...unknown[]]` with the standardized `Call` type, improving type consistency and maintainability across the codebase.

The `Call` type is re-exported so that libraries that use `@denops/std` can reuse it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal type definitions for batch call handling to use standardized type representations, enhancing code consistency and maintainability.

* **Chores**
  * Updated dependency version constraint for core library compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->